### PR TITLE
Commit of professionals search and rotate screen

### DIFF
--- a/src/pages/busqueda/[...params].js
+++ b/src/pages/busqueda/[...params].js
@@ -16,6 +16,7 @@ import FAIcon from '../../components/FAIcon';
 import NavPills from '../../components/NavPills';
 import ResultsMap from '../../components/ResultsMap';
 import NoResults from '../../components/Search/NoResults';
+import Profesionals from '../../components/Profesionals';
 
 const FiltersTitle = styled.h4`
   margin: 0.2em 0;
@@ -23,14 +24,14 @@ const FiltersTitle = styled.h4`
 `;
 
 const HideOnSm = styled.div`
-  @media (max-width: 576px) {
+  @media (max-width: 769px) {
     display: none;
   }
 `;
 
 const ShowOnSm = styled.div`
   display: none;
-  @media (max-width: 576px) {
+  @media (max-width: 769px) {
     display: block;
   }
 `;
@@ -47,13 +48,15 @@ const FilterButtonContainer = styled.div`
   button {
     pointer-events: all;
   }
+  z-index: 1500;
 `;
 
-const Busqueda = ({ results, filters, paging, availableFilters }) => {
+const Busqueda = ({ results, filters, paging, availableFilters, titlesList }) => {
   const [show, setShow] = useState(false);
   const [resultType, setResultType] = useState('list');
   return (
     <Container>
+      <Profesionals titlesList={titlesList}/>
       <Row>
         <Col md="3" className="mb-2">
           <div className="applied-filters">
@@ -132,6 +135,8 @@ export async function getServerSideProps({ query }) {
     .map((key) => `${key}=${params[key]}`)
     .join('&');
   const res = await fetch(`${server}/api/search?${qs}`);
+  const resSuggestions = await fetch(`${server}/api/suggestions`);
+  const { titlesList } = await resSuggestions.json();
   const {
     results,
     paging,
@@ -149,6 +154,7 @@ export async function getServerSideProps({ query }) {
       availableSorts,
       filters,
       availableFilters,
+      titlesList,
     },
   };
 }


### PR DESCRIPTION
Tareas de Trello:

* Páginas de profesionales sin busqueda: Importé y agregué el componente "Profesionals" en el archivo que se encuentra dentro de la carpeta "busqueda". También pasé dentro de las props, "titlesList" para que el usuario pueda volver a realizar otra búsqueda, de lo contrario, una vez que la búsqueda arrojaba un resultado, y quería buscar otra profesional, se rompía la página. 

* Problemas con la pantalla rotada del celular en búsqueda: Para la rotación lo que hice fue cambiar los estilos que se encuentran en el mismo archivo que el problema anterior (dentro de búsqueda). Cambié los max-width de las constantes "HideOnSm" y "ShowOnSm" para que el estilo de mobile se extienda a la pantalla rotada también. Por último le agregué un z-indez al botón que muestra los filtros ya que al hacer scroll, noté que los nombres de las profesionales lo tapaban, es decir, parecía que estaban por encima del botón.