### PR TITLE
se cambió la ruta del link de profesionales de la navegación

### DIFF
--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -75,7 +75,7 @@ const Navigation = (props) => {
           <Nav.Link href="/">Inicio</Nav.Link>
           <Nav.Link href="/articulos">Articulos</Nav.Link>
           <Nav.Link href="/eventos">Eventos</Nav.Link>
-          <Nav.Link href="/#profesionales">Profesionales</Nav.Link>
+          <Nav.Link href="/busqueda/results">Profesionales</Nav.Link>
           <Nav.Link href="/conocenos">Conocenos</Nav.Link>
           {!!profile && profile.role === 'admin' ? (
             <Nav.Link href="/administrar">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -55,7 +55,7 @@ const Home = ({ slides, theme, titlesList }) => {
             icon="fa fa-search"
             title="BUSCÁ"
             description="Completa el formulario y encontra el profesional que estés buscando"
-            href="/#profesionales"
+            href="/busqueda/results"
             color={theme.colors.mainOrange}
           />
           <Landing


### PR DESCRIPTION
Cambié la ruta del link de "Profesionales" de la navegación y le pasé "results" a la búsqueda que es la prop que trae a todos los profesionales.